### PR TITLE
missing capacity keyword

### DIFF
--- a/generic_dict/dict.mojo
+++ b/generic_dict/dict.mojo
@@ -44,7 +44,7 @@ struct Dict[
             self.key_hashes = DTypePointer[KeyCountType].alloc(self.capacity)
         else:
             self.key_hashes = DTypePointer[KeyCountType].alloc(0)
-        self.values = List[V](capacity)
+        self.values = List[V](capacity=capacity)
         self.key_map = DTypePointer[KeyCountType].alloc(self.capacity)
         memset_zero(self.key_map, self.capacity)
         @parameter


### PR DESCRIPTION
Added capactiy keyword to argument in generic dict 

```
 self.values = List[V](capacity=capacity)
 ```